### PR TITLE
Remove unordered_map and unordered_set from pack/variant

### DIFF
--- a/include/fc/array.hpp
+++ b/include/fc/array.hpp
@@ -140,7 +140,6 @@ namespace fc {
   }; 
 }
 
-#include <unordered_map>
 #include <fc/crypto/city.hpp>
 namespace std
 {
@@ -153,4 +152,3 @@ namespace std
        }
     };
 }
-

--- a/include/fc/crypto/sha224.hpp
+++ b/include/fc/crypto/sha224.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <unordered_map>
 #include <fc/fwd.hpp>
 #include <fc/io/raw_fwd.hpp>
 #include <fc/string.hpp>

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -397,31 +397,6 @@ namespace fc {
 
     } // namesapce detail
 
-    template<typename Stream, typename T>
-    inline void pack( Stream& s, const std::unordered_set<T>& value ) {
-      fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::pack( s, *itr );
-        ++itr;
-      }
-    }
-    template<typename Stream, typename T>
-    inline void unpack( Stream& s, std::unordered_set<T>& value ) {
-      unsigned_int size; fc::raw::unpack( s, size );
-      value.clear();
-      FC_ASSERT( size.value*sizeof(T) < MAX_ARRAY_ALLOC_SIZE );
-      value.reserve(size.value);
-      for( uint32_t i = 0; i < size.value; ++i )
-      {
-          T tmp;
-          fc::raw::unpack( s, tmp );
-          value.insert( std::move(tmp) );
-      }
-    }
-
-
     template<typename Stream, typename K, typename V>
     inline void pack( Stream& s, const std::pair<K,V>& value ) {
        fc::raw::pack( s, value.first );
@@ -434,30 +409,6 @@ namespace fc {
        fc::raw::unpack( s, value.second );
     }
 
-   template<typename Stream, typename K, typename V>
-    inline void pack( Stream& s, const std::unordered_map<K,V>& value ) {
-      fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::pack( s, *itr );
-        ++itr;
-      }
-    }
-    template<typename Stream, typename K, typename V>
-    inline void unpack( Stream& s, std::unordered_map<K,V>& value )
-    {
-      unsigned_int size; fc::raw::unpack( s, size );
-      value.clear();
-      FC_ASSERT( size.value*(sizeof(K)+sizeof(V)) < MAX_ARRAY_ALLOC_SIZE );
-      value.reserve(size.value);
-      for( uint32_t i = 0; i < size.value; ++i )
-      {
-          std::pair<K,V> tmp;
-          fc::raw::unpack( s, tmp );
-          value.insert( std::move(tmp) );
-      }
-    }
     template<typename Stream, typename K, typename V>
     inline void pack( Stream& s, const std::map<K,V>& value ) {
       fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -7,8 +7,6 @@
 #include <deque>
 #include <vector>
 #include <string>
-#include <unordered_set>
-#include <unordered_map>
 #include <set>
 
 #define MAX_ARRAY_ALLOC_SIZE (1024*1024*10) 
@@ -38,8 +36,6 @@ namespace fc {
 
     template<typename Stream, typename T> inline void pack( Stream& s, const std::set<T>& value );
     template<typename Stream, typename T> inline void unpack( Stream& s, std::set<T>& value );
-    template<typename Stream, typename T> inline void pack( Stream& s, const std::unordered_set<T>& value );
-    template<typename Stream, typename T> inline void unpack( Stream& s, std::unordered_set<T>& value );
 
     template<typename Stream, typename... T> void pack( Stream& s, const static_variant<T...>& sv );
     template<typename Stream, typename... T> void unpack( Stream& s, static_variant<T...>& sv );
@@ -49,9 +45,6 @@ namespace fc {
 
     template<typename Stream, typename T> inline void pack( Stream& s, const std::deque<T>& value );
     template<typename Stream, typename T> inline void unpack( Stream& s, std::deque<T>& value );
-
-    template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::unordered_map<K,V>& value );
-    template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::unordered_map<K,V>& value );
 
     template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::map<K,V>& value );
     template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::map<K,V>& value );

--- a/include/fc/io/varint.hpp
+++ b/include/fc/io/varint.hpp
@@ -77,7 +77,7 @@ void from_variant( const variant& var,  unsigned_int& vo );
 
 }  // namespace fc
 
-#include <unordered_map>
+#include <functional>
 namespace std
 {
    template<>

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -4,8 +4,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include <string.h> // memset
@@ -85,11 +83,6 @@ namespace fc
    void from_variant( const variant& var,  std::vector<char>& vo );
 
    template<typename K, typename T>
-   void to_variant( const std::unordered_map<K,T>& var,  variant& vo );
-   template<typename K, typename T>
-   void from_variant( const variant& var,  std::unordered_map<K,T>& vo );
-
-   template<typename K, typename T>
    void to_variant( const fc::flat_map<K,T>& var,  variant& vo );
    template<typename K, typename T>
    void from_variant( const variant& var, fc::flat_map<K,T>& vo );
@@ -102,12 +95,6 @@ namespace fc
    void to_variant( const std::multimap<K,T>& var,  variant& vo );
    template<typename K, typename T>
    void from_variant( const variant& var,  std::multimap<K,T>& vo );
-
-
-   template<typename T>
-   void to_variant( const std::unordered_set<T>& var,  variant& vo );
-   template<typename T>
-   void from_variant( const variant& var,  std::unordered_set<T>& vo );
 
    template<typename T>
    void to_variant( const std::deque<T>& var,  variant& vo );
@@ -364,44 +351,7 @@ namespace fc
           from_variant( var, *vo );
       }
    }
-   template<typename T>
-   void to_variant( const std::unordered_set<T>& var,  variant& vo )
-   {
-       std::vector<variant> vars(var.size());
-       size_t i = 0;
-       for( auto itr = var.begin(); itr != var.end(); ++itr, ++i )
-          vars[i] = variant(*itr);
-       vo = vars;
-   }
-   template<typename T>
-   void from_variant( const variant& var,  std::unordered_set<T>& vo )
-   {
-      const variants& vars = var.get_array();
-      vo.clear();
-      vo.reserve( vars.size() );
-      for( auto itr = vars.begin(); itr != vars.end(); ++itr )
-         vo.insert( itr->as<T>() );
-   }
 
-
-   template<typename K, typename T>
-   void to_variant( const std::unordered_map<K, T>& var,  variant& vo )
-   {
-       std::vector< variant > vars(var.size());
-       size_t i = 0;
-       for( auto itr = var.begin(); itr != var.end(); ++itr, ++i )
-          vars[i] = fc::variant(*itr);
-       vo = vars;
-   }
-   template<typename K, typename T>
-   void from_variant( const variant& var,  std::unordered_map<K, T>& vo )
-   {
-      const variants& vars = var.get_array();
-      vo.clear();
-      for( auto itr = vars.begin(); itr != vars.end(); ++itr )
-         vo.insert( itr->as< std::pair<K,T> >() );
-
-   }
    template<typename K, typename T>
    void to_variant( const std::map<K, T>& var,  variant& vo )
    {


### PR DESCRIPTION
These containers should not be reflected because the order cannot be guaranteed in JSON.
