### PR TITLE
Get rid of fc::shared_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,9 @@ set( fc_sources
      src/thread/spin_yield_lock.cpp
      src/thread/mutex.cpp
      src/thread/non_preemptable_scope_check.cpp
+     src/thread/shared_ptr.cpp
      src/asio.cpp
      src/string.cpp
-     src/shared_ptr.cpp
      src/time.cpp
      src/utf8.cpp
      src/io/iostream.cpp

--- a/include/fc/io/fstream.hpp
+++ b/include/fc/io/fstream.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <fc/shared_ptr.hpp>
+#include <memory>
 #include <fc/filesystem.hpp>
 #include <fc/io/iostream.hpp>
 #include <ios>
@@ -26,7 +26,7 @@ namespace fc {
 
     private:
       class impl;
-      fc::shared_ptr<impl> my;
+      std::unique_ptr<impl> my;
   };
 
   class ifstream : virtual public istream {
@@ -48,7 +48,7 @@ namespace fc {
       bool      eof()const;
     private:
       class impl;
-      fc::shared_ptr<impl> my;
+      std::unique_ptr<impl> my;
   };
 
   /**

--- a/include/fc/log/appender.hpp
+++ b/include/fc/log/appender.hpp
@@ -1,42 +1,43 @@
 #pragma once
-#include <fc/shared_ptr.hpp>
-#include <fc/string.hpp>
+#include <memory>
+//#include <fc/string.hpp>
 
 namespace fc {
    class appender;
    class log_message;
    class variant;
 
-   class appender_factory : public fc::retainable {
+   class appender_factory {
       public:
-       typedef fc::shared_ptr<appender_factory> ptr;
+       typedef std::shared_ptr<appender_factory> ptr;
 
        virtual ~appender_factory(){};
-       virtual fc::shared_ptr<appender> create( const variant& args ) = 0;
+       virtual std::shared_ptr<appender> create( const variant& args ) = 0;
    };
 
    namespace detail {
       template<typename T>
       class appender_factory_impl : public appender_factory {
         public:
-           virtual fc::shared_ptr<appender> create( const variant& args ) {
-              return fc::shared_ptr<appender>(new T(args));
+           virtual std::shared_ptr<appender> create( const variant& args ) {
+              return std::shared_ptr<appender>(new T(args));
            }
       };
    }
 
-   class appender : public fc::retainable {
+   class appender {
       public:
-         typedef fc::shared_ptr<appender> ptr;
+         typedef std::shared_ptr<appender> ptr;
+         virtual ~appender() = default;
 
          template<typename T>
          static bool register_appender(const std::string& type) {
-            return register_appender( type, new detail::appender_factory_impl<T>() );
+            return register_appender( type, std::make_shared<detail::appender_factory_impl<T>>() );
          }
 
-         static appender::ptr create( const std::string& name, const std::string& type, const variant& args  );
-         static appender::ptr get( const std::string& name );
-         static bool          register_appender( const std::string& type, const appender_factory::ptr& f );
+         static ptr create( const std::string& name, const std::string& type, const variant& args  );
+         static ptr get( const std::string& name );
+         static bool register_appender( const std::string& type, const appender_factory::ptr& f );
 
          virtual void log( const log_message& m ) = 0;
    };

--- a/include/fc/log/file_appender.hpp
+++ b/include/fc/log/file_appender.hpp
@@ -25,7 +25,7 @@ class file_appender : public appender {
 
       private:
          class impl;
-         fc::shared_ptr<impl> my;
+         std::shared_ptr<impl> my;
    };
 } // namespace fc
 

--- a/include/fc/log/gelf_appender.hpp
+++ b/include/fc/log/gelf_appender.hpp
@@ -23,7 +23,7 @@ namespace fc
 
   private:
     class impl;
-    fc::shared_ptr<impl> my;
+    std::shared_ptr<impl> my;
   };
 } // namespace fc
 

--- a/include/fc/log/log_message.hpp
+++ b/include/fc/log/log_message.hpp
@@ -3,10 +3,7 @@
  * @file log_message.hpp
  * @brief Defines types and helper macros necessary for generating log messages.
  */
-#include <fc/time.hpp>
 #include <fc/variant_object.hpp>
-#include <fc/shared_ptr.hpp>
-#include <memory>
 
 namespace fc
 {

--- a/include/fc/log/logger.hpp
+++ b/include/fc/log/logger.hpp
@@ -1,7 +1,5 @@
 #pragma once
-#include <fc/string.hpp>
-#include <fc/time.hpp>
-#include <fc/shared_ptr.hpp>
+#include <memory>
 #include <fc/log/log_message.hpp>
 
 namespace fc  
@@ -42,16 +40,16 @@ namespace fc
          void  set_name( const std::string& n );
          const std::string& name()const;
 
-         void add_appender( const fc::shared_ptr<appender>& a );
-         std::vector<fc::shared_ptr<appender> > get_appenders()const;
-         void remove_appender( const fc::shared_ptr<appender>& a );
+         void add_appender( const std::shared_ptr<appender>& a );
+         std::vector<std::shared_ptr<appender> > get_appenders()const;
+         void remove_appender( const std::shared_ptr<appender>& a );
 
          bool is_enabled( log_level e )const;
          void log( log_message m );
 
       private:
          class impl;
-         fc::shared_ptr<impl> my;
+         std::shared_ptr<impl> my;
    };
 
 } // namespace fc

--- a/include/fc/network/http/server.hpp
+++ b/include/fc/network/http/server.hpp
@@ -1,6 +1,5 @@
 #pragma once 
 #include <fc/network/http/connection.hpp>
-#include <fc/shared_ptr.hpp>
 #include <functional>
 #include <memory>
 
@@ -28,7 +27,7 @@ namespace fc { namespace http {
           class impl;
 
           response();
-          response( const fc::shared_ptr<impl>& my);
+          response( const std::shared_ptr<impl>& my);
           response( const response& r);
           response( response&& r );
           ~response();
@@ -42,7 +41,7 @@ namespace fc { namespace http {
           void write( const char* data, uint64_t len )const;
 
         private:
-          fc::shared_ptr<impl> my;
+          std::shared_ptr<impl> my;
       };
 
       void listen( const fc::ip::endpoint& p );

--- a/include/fc/network/udp_socket.hpp
+++ b/include/fc/network/udp_socket.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <fc/utility.hpp>
-#include <fc/shared_ptr.hpp>
 #include <memory>
 
 namespace fc {
@@ -37,7 +36,7 @@ namespace fc {
 
     private:
       class                impl;
-      fc::shared_ptr<impl> my;
+      std::shared_ptr<impl> my;
   };
 
 }

--- a/include/fc/thread/future.hpp
+++ b/include/fc/thread/future.hpp
@@ -1,7 +1,6 @@
 #pragma once
-#include <fc/utility.hpp>
 #include <fc/time.hpp>
-#include <fc/shared_ptr.hpp>
+#include <fc/thread/shared_ptr.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/thread/spin_yield_lock.hpp>
 #include <fc/optional.hpp>
@@ -326,4 +325,3 @@ namespace fc {
       fc::shared_ptr<promise<void>> m_prom;
   };
 } 
-

--- a/include/fc/thread/shared_ptr.hpp
+++ b/include/fc/thread/shared_ptr.hpp
@@ -87,4 +87,3 @@ namespace fc {
     return fc::shared_ptr<T>( static_cast<T*>(t.get()), true );
   }
 }
-

--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <fc/variant.hpp>
-#include <fc/shared_ptr.hpp>
 
 namespace fc
 {

--- a/src/io/fstream.cpp
+++ b/src/io/fstream.cpp
@@ -11,11 +11,11 @@
 #include <boost/filesystem/fstream.hpp>
 
 namespace fc {
-   class ofstream::impl : public fc::retainable {
+   class ofstream::impl {
       public:
          boost::filesystem::ofstream ofs;
    };
-   class ifstream::impl : public fc::retainable {
+   class ifstream::impl {
       public:
          boost::filesystem::ifstream ifs;
    };

--- a/src/log/console_appender.cpp
+++ b/src/log/console_appender.cpp
@@ -2,6 +2,7 @@
 #include <fc/log/log_message.hpp>
 #include <fc/thread/unique_lock.hpp>
 #include <fc/string.hpp>
+#include <fc/time.hpp>
 #include <fc/variant.hpp>
 #include <fc/reflect/variant.hpp>
 #ifndef WIN32

--- a/src/log/file_appender.cpp
+++ b/src/log/file_appender.cpp
@@ -14,7 +14,7 @@
 
 namespace fc {
 
-   class file_appender::impl : public fc::retainable
+   class file_appender::impl
    {
       public:
          config                     cfg;

--- a/src/log/gelf_appender.cpp
+++ b/src/log/gelf_appender.cpp
@@ -20,7 +20,7 @@
 namespace fc 
 {
 
-  class gelf_appender::impl : public retainable
+  class gelf_appender::impl
   {
   public:
     config                     cfg;

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -11,7 +11,7 @@
 
 namespace fc {
 
-    class logger::impl : public fc::retainable {
+    class logger::impl {
       public:
          impl()
          :_parent(nullptr),_enabled(true),_additivity(false),_level(log_level::warn){}
@@ -55,7 +55,7 @@ namespace fc {
        return *this;
     }
     bool operator==( const logger& l, std::nullptr_t ) { return !l.my; }
-    bool operator!=( const logger& l, std::nullptr_t ) { return l.my;  }
+    bool operator!=( const logger& l, std::nullptr_t ) { return !!l.my;  }
 
     bool logger::is_enabled( log_level e )const {
        return e >= my->_level;
@@ -96,13 +96,13 @@ namespace fc {
     log_level logger::get_log_level()const { return my->_level; }
     logger& logger::set_log_level(log_level ll) { my->_level = ll; return *this; }
 
-    void logger::add_appender( const fc::shared_ptr<appender>& a )
+    void logger::add_appender( const std::shared_ptr<appender>& a )
     { my->_appenders.push_back(a); }
     
 //    void logger::remove_appender( const fc::shared_ptr<appender>& a )
  //   { my->_appenders.erase(a); }
 
-    std::vector<fc::shared_ptr<appender> > logger::get_appenders()const
+    std::vector<std::shared_ptr<appender> > logger::get_appenders()const
     {
         return my->_appenders;
     }

--- a/src/network/http/http_server.cpp
+++ b/src/network/http/http_server.cpp
@@ -9,7 +9,7 @@
 
 namespace fc { namespace http {
 
-  class server::response::impl : public fc::retainable
+  class server::response::impl
   {
     public:
       impl( const fc::http::connection_ptr& c, const std::function<void()>& cont = std::function<void()>() )
@@ -112,7 +112,7 @@ namespace fc { namespace http {
       {
         try 
         {
-          http::server::response rep( fc::shared_ptr<response::impl>( new response::impl(c) ) );
+          http::server::response rep( std::shared_ptr<response::impl>( new response::impl(c) ) );
           if (!cors_domains.empty())
             rep.add_header("Access-Control-Allow-Origin", cors_domains);
 
@@ -164,7 +164,7 @@ namespace fc { namespace http {
   server::response::response(){}
   server::response::response( const server::response& s ):my(s.my){}
   server::response::response( server::response&& s ):my(fc::move(s.my)){}
-  server::response::response( const fc::shared_ptr<server::response::impl>& m ):my(m){}
+  server::response::response( const std::shared_ptr<server::response::impl>& m ):my(m){}
 
   server::response& server::response::operator=(const server::response& s) { my = s.my; return *this; }
   server::response& server::response::operator=(server::response&& s)      { fc_swap(my,s.my); return *this; }

--- a/src/network/udp_socket.cpp
+++ b/src/network/udp_socket.cpp
@@ -6,7 +6,7 @@
 
 namespace fc {
   
-  class udp_socket::impl : public fc::retainable {
+  class udp_socket::impl {
     public:
       impl():_sock( fc::asio::default_io_service() ){}
       ~impl(){

--- a/src/thread/shared_ptr.cpp
+++ b/src/thread/shared_ptr.cpp
@@ -1,4 +1,4 @@
-#include <fc/shared_ptr.hpp>
+#include <fc/thread/shared_ptr.hpp>
 #include <boost/atomic.hpp>
 #include <boost/memory_order.hpp>
 #include <assert.h>


### PR DESCRIPTION
Usage has only been left in thread module
